### PR TITLE
Fix flipping bug

### DIFF
--- a/game/board.py
+++ b/game/board.py
@@ -125,7 +125,7 @@ class Board(object):
             if (tile >= 0) and (tile < WIDTH*HEIGHT):
                 while self.pieces[tile].get_state() != BOARD:
                     to_flip.append(self.pieces[tile])
-                    if self.outside_board(tile, d):
+                    if self.pieces[tile].get_state() == player or self.outside_board(tile, d):
                         break
                     else:
                         tile += d


### PR DESCRIPTION
make these move:

BLACK, d3
WHITE, c5
BLACK, b6
WHITE, e3
BLACK, f2
WHITE, c2
BLACK, f6
WHITE, b5
BLACK, a5
WHITE, e2
BLACK, f3
WHITE, e6
BLACK, d2
WHITE, c4
BLACK, f4
WHITE, g1
BLACK, b4
WHITE, g7
BLACK, h8
WHITE, g2 !!

![screenshot from 2018-01-11 15 52 50](https://user-images.githubusercontent.com/15082799/34814146-8e1bb5c4-f6e7-11e7-945d-3144bd9ff6c8.png)

the flipping bug is appearing, when WHITE is moved onto g2.

![screenshot from 2018-01-11 15 53 08](https://user-images.githubusercontent.com/15082799/34814176-a567e7b6-f6e7-11e7-9d33-287ea488fd54.png)
