### PR TITLE
Fix wrong rule

### DIFF
--- a/game/game.py
+++ b/game/game.py
@@ -31,6 +31,7 @@ class Game(object):
         self.board.set_white(3, 3)
         self.board.mark_moves(self.player)
         self.previous_move = None
+        self.previous_round_passed = False
 
     def _make_controller(self, colour, controller_type):
         """ Returns a controller with the specified colour.
@@ -87,20 +88,24 @@ class Game(object):
                 self.show_commands()
                 next_move = self.controllers[0].next_move(self.board)
                 self.board.make_move(next_move, self.controllers[0].get_colour())
+                self.previous_round_passed = False
             except NoMovesError:
-                print("Game Over")
-                blacks = len([p for p in self.board.pieces if p.get_state() == BLACK])
-                whites = len([p for p in self.board.pieces if p.get_state() == WHITE])
+                if self.previous_round_passed:
+                    print("Game Over")
+                    blacks = len([p for p in self.board.pieces if p.get_state() == BLACK])
+                    whites = len([p for p in self.board.pieces if p.get_state() == WHITE])
 
-                if blacks > whites:
-                    print("Black won this game.")
-                    exit()
-                elif blacks == whites:
-                    print("This game was a tie.")
-                    exit()
+                    if blacks > whites:
+                        print("Black won this game.")
+                        exit()
+                    elif blacks == whites:
+                        print("This game was a tie.")
+                        exit()
+                    else:
+                        print("White won this game.")
+                        exit()
                 else:
-                    print("White won this game.")
-                    exit()
+                    self.previous_round_passed = True
 
             self.controllers.rotate()
 


### PR DESCRIPTION
According to [Wikipedia](https://en.wikipedia.org/wiki/Reversi#Rules), if one player can not make a valid move, play passes back to the other player. When neither player can move, the game ends.

But the original program did a wrong policy that if player can not make a valid move, then it raises `NoMovesError` and immediately ends the game.

Example:

BLACK, e6
WHITE, f6
BLACK, c4
WHITE, c5
BLACK, c6
WHITE, d6
BLACK, g7
WHITE, f4
BLACK, g4
WHITE, g6
BLACK, e7
WHITE, h8
BLACK, h6
WHITE, g5
BLACK, g8
WHITE, f8 !!

The behavior of original program:
![screenshot from 2018-01-11 17 57 48](https://user-images.githubusercontent.com/15082799/34819741-98acd2cc-f6f9-11e7-8b79-4093d269b3d6.png)
![screenshot from 2018-01-11 17 58 07](https://user-images.githubusercontent.com/15082799/34819745-9ab5faf8-f6f9-11e7-8bce-6e1bf8ed1a22.png)
